### PR TITLE
Quick fix for body margin

### DIFF
--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -13,7 +13,7 @@ export const GlobalStyles = createGlobalStyle`
 
   body {
     background-color: ${({ theme }) => theme.color.bgLightGrey};
-    margin: 150px auto 103px;
+    margin: 150px auto 103px !important;
     width: 1368px;
     max-width: 85%;
     font-family: "Poppins", sans-serif;


### PR DESCRIPTION
# Quick fix for body margin

This simple quick fix addresses a problem with centering content caused by a conflict with the body margin included in styled-normalize. The use of **!important** resolves the issue, ensuring proper centering of content.