### PR TITLE
Limited totalPages to 500 for People page

### DIFF
--- a/src/features/People/usePeople.js
+++ b/src/features/People/usePeople.js
@@ -5,7 +5,6 @@ import {
     fetchPeopleListLoad,
     selectPeopleList,
     selectStatus,
-    selectTotalPeoplePages,
     selectPeopleListState
 } from "./peopleSlice";
 import {
@@ -21,7 +20,7 @@ export const usePeople = () => {
     const status = useSelector(selectStatus);
     const popularPeople = useSelector(selectPeopleList);
 
-    const totalPages = useSelector(selectTotalPeoplePages);
+    const totalPages = 500;
     const { currentPage } = useSelector(selectPeopleListState);
     const selectedPage = useSelector(selectPage);
 


### PR DESCRIPTION
# Limited totalPages to 500 for People page

Due to recent API limit changes, **totalPages** for the People page is now limited to **500**.
This adjustment prevents error messages when navigating to the last page.

> **Important!**
>
> Similar to MovieList, the total pages selector for People is retained in the slice for potential future use.